### PR TITLE
Part 7 - Guest User access

### DIFF
--- a/amplify/backend/api/sqacamplify/parameters.json
+++ b/amplify/backend/api/sqacamplify/parameters.json
@@ -1,11 +1,5 @@
 {
     "AppSyncApiName": "sqacamplify",
     "DynamoDBBillingMode": "PROVISIONED",
-    "DynamoDBEnableServerSideEncryption": "false",
-    "AuthCognitoUserPoolId": {
-        "Fn::GetAtt": [
-            "authsqacauth",
-            "Outputs.UserPoolId"
-        ]
-    }
+    "DynamoDBEnableServerSideEncryption": "false"
 }

--- a/amplify/backend/api/sqacamplify/schema.graphql
+++ b/amplify/backend/api/sqacamplify/schema.graphql
@@ -1,6 +1,7 @@
 type Collection
   # Store in DynamoDB, disable mutations and subscriptions
   @model( mutations: null, subscriptions: null)
+  @auth(rules: [{allow: public, provider: iam}])
 {
   id: ID!
   created: String!

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -1,48 +1,53 @@
 {
-    "hosting": {
-        "S3AndCloudFront": {
-            "service": "S3AndCloudFront",
-            "providerPlugin": "awscloudformation"
-        }
-    },
-    "auth": {
-        "sqacauth": {
-            "service": "Cognito",
-            "providerPlugin": "awscloudformation",
-            "dependsOn": []
-        }
-    },
-    "storage": {
-        "storage": {
-            "service": "S3",
-            "providerPlugin": "awscloudformation",
-            "dependsOn": [
-                {
-                    "category": "function",
-                    "resourceName": "S3Trigger08755fbf",
-                    "attributes": [
-                        "Name",
-                        "Arn",
-                        "LambdaExecutionRole"
-                    ]
-                }
-            ]
-        }
-    },
-    "function": {
-        "S3Trigger08755fbf": {
-            "service": "Lambda",
-            "providerPlugin": "awscloudformation",
-            "build": true
-        }
-    },
-    "api": {
-        "sqacamplify": {
-            "service": "AppSync",
-            "providerPlugin": "awscloudformation",
-            "output": {
-                "securityType": "AMAZON_COGNITO_USER_POOLS"
-            }
-        }
-    }
+	"hosting": {
+		"S3AndCloudFront": {
+			"service": "S3AndCloudFront",
+			"providerPlugin": "awscloudformation"
+		}
+	},
+	"auth": {
+		"sqacauth": {
+			"service": "Cognito",
+			"providerPlugin": "awscloudformation",
+			"dependsOn": []
+		}
+	},
+	"storage": {
+		"storage": {
+			"service": "S3",
+			"providerPlugin": "awscloudformation",
+			"dependsOn": [
+				{
+					"category": "function",
+					"resourceName": "S3Trigger08755fbf",
+					"attributes": [
+						"Name",
+						"Arn",
+						"LambdaExecutionRole"
+					]
+				}
+			]
+		}
+	},
+	"function": {
+		"S3Trigger08755fbf": {
+			"service": "Lambda",
+			"providerPlugin": "awscloudformation",
+			"build": true
+		}
+	},
+	"api": {
+		"sqacamplify": {
+			"service": "AppSync",
+			"providerPlugin": "awscloudformation",
+			"output": {
+				"authConfig": {
+					"additionalAuthenticationProviders": [],
+					"defaultAuthentication": {
+						"authenticationType": "AWS_IAM"
+					}
+				}
+			}
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,15 +1587,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.11.tgz",
-      "integrity": "sha512-dNd2pp8qTzzNLAs3O8nH3iU9DG9866KHq9L3ISPB7DOGERZN81nW/5/g/KzMJpCU8jrbCiMRBzV9/sCEdRosig==",
+      "version": "10.17.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+      "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
       "dev": true
     },
     "@types/nouislider": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@types/nouislider/-/nouislider-9.0.5.tgz",
-      "integrity": "sha512-aLBm0j0y2mjblIJMcVgxPEmILBqlctCPs5FAsW01SawzXDBRZ0dHiOdbElQclui0tQjZokN0L1GnuyPRiXty0g==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/nouislider/-/nouislider-9.0.6.tgz",
+      "integrity": "sha512-ASkRBlWX5qiAucW08jS2/ZGKJQWqx/JWJ52fU7LCLRRtfOaOCqYsZmBYJdIG3j+MRX2ZSaB0nglFujPGckLn4Q==",
       "dev": true,
       "requires": {
         "@types/wnumb": "*"
@@ -3403,9 +3403,9 @@
       }
     },
     "core-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
-      "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
+      "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ=="
     },
     "core-js-compat": {
       "version": "3.6.0",
@@ -8373,9 +8373,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "serve:prod": "npm run build:prod && npm run serve:dist",
     "lint": "ng lint",
     "clean": "rm -R dist/",
+    "publish": "amplify publish --invalidateCloudFront",
     "amplify:S3Trigger08755fbf": "cd amplify/backend/function/S3Trigger08755fbf/src/ && npm run build"
   },
   "dependencies": {
@@ -31,7 +32,7 @@
     "aws-amplify": "^2.2.1",
     "aws-amplify-angular": "^4.1.2",
     "bootstrap": "^3.3.7",
-    "core-js": "^3.6.0",
+    "core-js": "^3.6.1",
     "image-to-data-uri": "^1.1.0",
     "localforage": "^1.7.3",
     "ng-sidebar": "^9.2.0",
@@ -39,7 +40,7 @@
     "ngx-toastr": "^11.2.1",
     "nouislider": "^10.1.0",
     "random-js": "^1.0.8",
-    "rxjs": "^6.5.3",
+    "rxjs": "^6.5.4",
     "uuid": "^3.3.3",
     "zone.js": "~0.9.1"
   },
@@ -49,8 +50,8 @@
     "@angular/compiler-cli": "^8.0.3",
     "@types/aws-lambda": "^8.10.39",
     "@types/jasmine": "^2.8.9",
-    "@types/node": "^10.17.11",
-    "@types/nouislider": "^9.0.5",
+    "@types/node": "^10.17.13",
+    "@types/nouislider": "^9.0.6",
     "codelyzer": "^5.2.1",
     "http-server": "^0.12.0",
     "jasmine-core": "~2.5.2",

--- a/src/app/API.service.ts
+++ b/src/app/API.service.ts
@@ -2,6 +2,8 @@
 //  This file was automatically generated and should not be edited.
 import { Injectable } from "@angular/core";
 import API, { graphqlOperation } from "@aws-amplify/api";
+import { GraphQLResult } from "@aws-amplify/api/lib/types";
+import * as Observable from "zen-observable";
 
 export type ModelCollectionFilterInput = {
   id?: ModelIDFilterInput | null;
@@ -58,8 +60,6 @@ export type ModelIntFilterInput = {
   lt?: number | null;
   ge?: number | null;
   gt?: number | null;
-  contains?: number | null;
-  notContains?: number | null;
   between?: Array<number | null> | null;
 };
 

--- a/src/app/collections/list-collections.component.html
+++ b/src/app/collections/list-collections.component.html
@@ -13,7 +13,7 @@
             <li><a [routerLink]="['/collections']">Collections</a></li>
             <li class="active">{{showOnly.name}}</li>
         </ol>
-        <div *ngIf="!showOnly" class="text-right">
+        <div *ngIf="!showOnly && userSvc.isCloudUser()" class="text-right">
             <button type="button" class="btn btn-danger btn-circle btn-lg btn-float-bottom-right"
                     (click)="onCreateCollection()" title="Create New">
                 <span class="glyphicon glyphicon-plus"></span>

--- a/src/app/collections/list-collections.component.ts
+++ b/src/app/collections/list-collections.component.ts
@@ -219,7 +219,7 @@ export class ListCollectionsComponent extends AbstractBaseComponent implements O
      * Unsubscribe from the active collection... Called when user confirms.
      */
     doUnsubscribe() {
-        this.settings.collections.delete(this.activeCollection.id);
+        this.settings.unsubscribeCollection(this.activeCollection);
         this.syncSvc.setDirty(this.settings);
         this.collectionSvc.loadFrom(this.settings).then();
         // Upon the reload completing, refreshCollectionList() is automatically triggered.

--- a/src/app/collections/list-collections.component.ts
+++ b/src/app/collections/list-collections.component.ts
@@ -30,7 +30,7 @@ export class ListCollectionsComponent extends AbstractBaseComponent implements O
     appliedFilter: CollectionFilter;
 
     /** If set, only showing this one collection */
-    showOnly = undefined;
+    showOnly: Collection|undefined;
 
     settings: UserSettings;
 

--- a/src/app/collections/search-collections.component.ts
+++ b/src/app/collections/search-collections.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {AbstractBaseComponent} from "../shared/abstract-base.component";
-import {CollectionJSON} from "../models/collection";
+import {Collection, CollectionJSON} from '../models/collection';
 import {UserService} from "../services/user.service";
 import {CollectionService} from "../services/collection.service";
 import {UserSettings} from "../models/user-settings";
@@ -8,6 +8,8 @@ import {CollectionFilter} from "./widget/collection-filter.component";
 import {SyncService} from "../services/sync.service";
 import {takeUntil} from "rxjs/operators";
 import {APIService, ModelCollectionFilterInput} from '../API.service';
+import {StorageLocation} from '../services/persistence.service';
+import {AbstractStorableModel} from '../models/abstract-storable-model';
 
 interface CollectionView extends CollectionJSON {
     path: string;
@@ -79,14 +81,14 @@ export class SearchCollectionsComponent extends AbstractBaseComponent implements
 
         // Add view properties
         this.collections.forEach(col => {
-            col.path = col.authorUserId + '/' + col.id;
+            col.path = new StorageLocation((col as any) as AbstractStorableModel).path;
             col.isSubscribed = (col.authorUserId === this.settings.id) || this.settings.collections.has(col.path);
         });
     }
 
     subscribe(collection: CollectionView) {
         collection.isSubscribed = true;
-        this.settings.collections.add(collection.path);
+        this.settings.subscribeCollection((collection as any) as Collection);
         this.settings.isDirty = true;
     }
 }

--- a/src/app/collections/search-collections.component.ts
+++ b/src/app/collections/search-collections.component.ts
@@ -8,7 +8,7 @@ import {CollectionFilter} from "./widget/collection-filter.component";
 import {SyncService} from "../services/sync.service";
 import {takeUntil} from "rxjs/operators";
 import {APIService, ModelCollectionFilterInput} from '../API.service';
-import {StorageLocation} from '../services/persistence.service';
+import {StorageLocation} from '../models/storage-location';
 import {AbstractStorableModel} from '../models/abstract-storable-model';
 
 interface CollectionView extends CollectionJSON {

--- a/src/app/home/account.component.html
+++ b/src/app/home/account.component.html
@@ -68,6 +68,6 @@
     <hr class="text" data-content="or">
     <div class="sign-in-google" (click)="signInWithGoogle()"></div>
     <p class="text-info small">
-        Google will only share your name and email address. Your photo will be displayed only to you.
+        Google will only share your name and email address. Your photo will be displayed to you.
     </p>
 </ng-template>

--- a/src/app/home/account.component.html
+++ b/src/app/home/account.component.html
@@ -10,38 +10,64 @@
     </div>
 
     <div *ngIf="!userSettings && syncSvc.isOnline()" class="container-fluid text-center">
-        <div class="amplify-block">
-            <amplify-authenticator [signUpConfig]="signUpConfig"
-                                   usernameAttributes="email">
-            </amplify-authenticator>
-            <hr>
-            <i>or</i>
-            <div class="sign-in-google" (click)="signInWithGoogle()"></div>
+        <h3>Local Only</h3>
+        <div>
+            <p class="text-info small">
+                A local account lets you use dance to public module collections and create your own sessions.
+                Your subscriptions and sessions are only stored locally in this browser, and could be lost.
+            </p>
+            <button class="btn btn-default" (click)="localSignUp()">Create Local Account</button>
         </div>
-        <hr>
-        <p class="text-info small">
-            Your account is only used for basic identification, so that you can backup your data and share between your,
-            and <i>only your</i> devices. (Unless you <i>choose</i> to share with others.)
-            <br>
-            SqAC does not gain access to your social feeds, shopping, or anything of the sort.
-            <br>
-            These providers will tell you if special permissions were being requested.
-            They are just used so that SqAC can focus on calling, and not account maintenance.
-            <br>
-            Once you choose a provider, you must continue using it each time. Choosing a different provider
-            will result in a separate SqAC account.
-        </p>
+
+        <hr style="margin: 30px 0">
+
+        <h3>Cloud Storage</h3>
+        <ng-container *ngTemplateOutlet="cloudLogin"></ng-container>
     </div>
 
     <div *ngIf="userSettings" class="container-fluid text-center">
         <img [src]="userSvc.info.photo" class="img-rounded" style="width: 96px; height: 96px">
-        <h4 class="text-success">You are signed in with {{userSettings.getAuthProviderName()}} as <em>{{userSettings.name}}</em>.</h4>
-        <button type="button" class="btn btn-primary" (click)="syncWithCloud()" [disabled]="!syncSvc.isOnline()">
-            Update collections from cloud storage.
-        </button>
-        <hr>
-        <button type="button" class="btn btn-danger" (click)="signOut()" [disabled]="!syncSvc.isOnline()">
-            Sign Out
-        </button>
+        <h4 class="text-success">You are signed in with {{userSvc.info.provider}} as <em>{{userSettings.name}}</em>.</h4>
+
+        <div *ngIf="userSvc.isCloudUser()">
+            <button class="btn btn-primary" (click)="syncWithCloud()" [disabled]="!syncSvc.isOnline()">
+                Update collections from cloud storage.
+            </button>
+            <hr>
+            <button type="button" class="btn btn-danger" (click)="signOut()" [disabled]="!syncSvc.isOnline()">
+                Sign Out
+            </button>
+        </div>
+
+        <div *ngIf="userSvc.isLocalUser()">
+            <p class="text-info small">
+                This local account lets you use dance to public module collections and create your own sessions.
+                Your subscriptions and sessions are only stored locally in this browser, and could be lost.
+            </p>
+            <button type="button" class="btn btn-danger" (click)="signOut()">
+                Destroy Local Account
+            </button>
+            <hr style="margin: 30px 0">
+            <h3>Upgrade to Cloud Storage</h3>
+            <ng-container *ngTemplateOutlet="cloudLogin"></ng-container>
+        </div>
     </div>
 </div>
+
+<ng-template #cloudLogin>
+    <p class="text-info small">
+        A free cloud account lets you backup your data and share between <i>your</i> devices.
+        It also allows you to create your own collections of dance modules, which you may <i>choose</i>
+        to share with others.
+    </p>
+    <div class="amplify-block">
+        <amplify-authenticator [signUpConfig]="signUpConfig"
+                               usernameAttributes="email">
+        </amplify-authenticator>
+    </div>
+    <hr class="text" data-content="or">
+    <div class="sign-in-google" (click)="signInWithGoogle()"></div>
+    <p class="text-info small">
+        Google will only share your name and email address. Your photo will be displayed only to you.
+    </p>
+</ng-template>

--- a/src/app/home/account.component.ts
+++ b/src/app/home/account.component.ts
@@ -80,4 +80,8 @@ export class AccountComponent extends AbstractBaseComponent implements OnInit {
     signInWithGoogle() {
         this.amplifySvc.auth().federatedSignIn({provider: 'Google'});
     }
+
+    localSignUp() {
+        this.userSvc.createLocalAccount();
+    }
 }

--- a/src/app/models/auth-user.ts
+++ b/src/app/models/auth-user.ts
@@ -14,4 +14,6 @@ export interface AuthUser {
     /** DataURI of the user's profile picture */
     photo: string;
 
+    /** ID provider */
+    provider: string;
 }

--- a/src/app/models/collection.ts
+++ b/src/app/models/collection.ts
@@ -100,10 +100,10 @@ export class Collection extends AbstractStorableModel {
         o.isPublic = json.isPublic;
         o.difficulty = (+json.difficulty) as Difficulty;
         o.level = json.level as DanceLevel;
-        o.formations = json.formations.map(f => Formation.fromJSON(f));
-        o.families = json.families.map(f => Family.fromJSON(f));
-        o.calls = json.calls.map(c => Call.fromJSON(c));
-        o.modules = json.modules.map(m => Module.fromJSON(m));
+        o.formations = Array.isArray(json.formations) ? json.formations.map(f => Formation.fromJSON(f)) : [];
+        o.families = Array.isArray(json.families) ? json.families.map(f => Family.fromJSON(f)) : [];
+        o.calls = Array.isArray(json.calls) ? json.calls.map(c => Call.fromJSON(c)) : [];
+        o.modules = Array.isArray(json.modules) ? json.modules.map(m => Module.fromJSON(m)) : [];
         o.license = json.license || "";
         return o;
     }

--- a/src/app/models/storage-location.ts
+++ b/src/app/models/storage-location.ts
@@ -1,0 +1,83 @@
+import {AbstractStorableModel} from './abstract-storable-model';
+import {Collection} from './collection';
+
+export class StorageLocation {
+    /**
+     * Location expressed as a single string.
+     * If public: <identityId>/<id>
+     * If private: <id>+<revision>
+     */
+    readonly path: string;
+
+    /** Model id */
+    readonly id?: string;
+    /** Model revision number */
+    readonly revision?: number;
+
+    /** S3 Object Key */
+    readonly key: string;
+    readonly level: 'private' | 'protected';
+    /** User ID, if level is 'protected' */
+    readonly identityId?: string;
+
+
+    /**
+     * Convert either an AbstractStorableModel or a path to a one into the S3 storage location.
+     *
+     * @param modelOrPath a data model to make a location out of, or a path to content
+     * @param forcePrivate if true, force to use private location even if modelOrPath can be public
+     */
+    constructor(modelOrPath: AbstractStorableModel | string, forcePrivate = false) {
+        if (typeof modelOrPath === 'string') {
+            // Path is just the ID when private.
+            // When public the path has the user ID '/' model ID, with no +rev.
+            const path = modelOrPath as string;
+            const slashIdx = path.indexOf('/');
+            const plusIdx = path.indexOf('+', slashIdx);
+            if (slashIdx > 0 && !forcePrivate) {
+                this.path = path;
+                this.id = path.substring(slashIdx + 1, plusIdx > slashIdx ? plusIdx : undefined);
+                this.revision = plusIdx > slashIdx ? +path.substring(plusIdx + 1) : undefined;
+                this.key = path.substring(slashIdx + 1);
+                this.level = 'protected';
+                this.identityId = path.substring(0, slashIdx);
+            } else {
+                this.path = path;
+                this.id = plusIdx > 0 ? path.substring(0, plusIdx) : path;
+                this.revision = plusIdx > 0 ? +path.substring(plusIdx + 1) : undefined;
+                this.key = path;
+                this.level = 'private';
+            }
+        } else if ((modelOrPath as Collection).authorUserId) {
+            const collection = modelOrPath as Collection;
+            const isPublic = collection.isPublic && !forcePrivate;
+            this.level = isPublic ? 'protected' : 'private';
+            this.id = collection.id;
+            this.revision = collection.revision;
+            this.key = isPublic ? collection.id : collection.id + '+' + collection.revision;
+            this.identityId = collection.isPublic ? collection.authorUserId : undefined;
+            this.path = collection.isPublic ? collection.authorUserId + '/' + this.key : this.key;
+        } else {
+            // Some other AbstractStorableModel - always private
+            const model = modelOrPath as AbstractStorableModel;
+            this.id = model.id;
+            this.revision = model.revision;
+            this.key = this.id + '+' + this.revision;
+            this.level = 'private';
+            this.path = this.key;
+        }
+    }
+
+    /**
+     * Create config options for Amplify StorageClass operations
+     * @param doDownload set to true for get operation to download content
+     */
+    toStorageConfig(doDownload?: boolean): any {
+        return {
+            level: this.level,
+            identityId: this.identityId,
+            download: doDownload === true,
+            contentType: "application/json",
+        };
+    }
+}

--- a/src/app/models/user-settings.ts
+++ b/src/app/models/user-settings.ts
@@ -2,7 +2,7 @@
 import { AbstractStorableModel, AbstractStorableModelJSON } from "./abstract-storable-model";
 import { DanceSession, DanceSessionJSON } from "./dance-session";
 import {Collection} from './collection';
-import {StorageLocation} from '../services/persistence.service';
+import {StorageLocation} from './storage-location';
 
 /*
  * AuthUser's application settings.

--- a/src/app/models/user-settings.ts
+++ b/src/app/models/user-settings.ts
@@ -1,6 +1,8 @@
 /* tslint:disable:member-ordering */
 import { AbstractStorableModel, AbstractStorableModelJSON } from "./abstract-storable-model";
 import { DanceSession, DanceSessionJSON } from "./dance-session";
+import {Collection} from './collection';
+import {StorageLocation} from '../services/persistence.service';
 
 /*
  * AuthUser's application settings.
@@ -32,6 +34,14 @@ export class UserSettings extends AbstractStorableModel {
         super(1, userId);
     }
 
+    subscribeCollection(collection: Collection) {
+        this.collections.add(new StorageLocation(collection).path);
+    }
+
+    unsubscribeCollection(collection: Collection) {
+        this.collections.delete(new StorageLocation(collection).path);
+    }
+
     /** Serialize this instance into JSON */
     public toJSON(): UserSettingsJSON {
         const json = super.toJSON() as UserSettingsJSON;
@@ -60,25 +70,6 @@ export class UserSettings extends AbstractStorableModel {
             o.activeSession = o.sessions.find((session) => session.id === json.activeSession);
         }
         return o;
-    }
-
-    /**
-     * Get the name of the authentication provider used by this user.
-     * @deprecated no longer useful?
-     */
-    getAuthProviderName(): string {
-        if (!this.id) {
-            return "";
-        }
-        else if (this.id.startsWith("google")) {
-            return "Google";
-        }
-        else if (this.id.startsWith("facebook")) {
-            return "Facebook";
-        }
-        else {
-            return "SqAC";
-        }
     }
 }
 

--- a/src/app/services/persistence.service.ts
+++ b/src/app/services/persistence.service.ts
@@ -232,7 +232,9 @@ export class PersistenceService {
      * @throws {PersistenceException} upon unhandled failure.
      */
     cloudSaveCollection(collection: Collection): Promise<Collection> {
-        return this.saveModelToCloud(collection, new StorageLocation(collection, true));
+        return (this.isLocalUser)
+            ? Promise.resolve(collection)
+            : this.saveModelToCloud(collection, new StorageLocation(collection, true));
     }
 
     /**

--- a/src/app/services/persistence.service.ts
+++ b/src/app/services/persistence.service.ts
@@ -7,6 +7,7 @@ import {SyncService} from "./sync.service";
 import {AmplifyService} from 'aws-amplify-angular';
 import {AuthClass, StorageClass} from 'aws-amplify';
 import {ExpiringValue} from '@sailplane/expiring-value/dist/expiring-value';
+import {StorageLocation} from '../models/storage-location';
 
 const CLOUD_LIST_PERIOD = 10_000; // ten seconds
 
@@ -397,86 +398,5 @@ export class PersistenceService {
         const ex = new PersistenceException(status, errMsg, error);
         console.error(ex.toString(), error);
         return ex;
-    }
-}
-
-export class StorageLocation {
-    /**
-     * Location expressed as a single string.
-     * If public: <identityId>/<id>
-     * If private: <id>+<revision>
-     */
-    readonly path: string;
-
-    /** Model id */
-    readonly id?: string;
-    /** Model revision number */
-    readonly revision?: number;
-
-    /** S3 Object Key */
-    readonly key: string;
-    readonly level: 'private' | 'protected';
-    /** User ID, if level is 'protected' */
-    readonly identityId?: string;
-
-
-    /**
-     * Convert either an AbstractStorableModel or a path to a one into the S3 storage location.
-     *
-     * @param modelOrPath a data model to make a location out of, or a path to content
-     * @param forcePrivate if true, force to use private location even if modelOrPath can be public
-     */
-    constructor(modelOrPath: AbstractStorableModel | string, forcePrivate = false) {
-        if (typeof modelOrPath === 'string') {
-            // Path is just the ID when private.
-            // When public the path has the user ID '/' model ID, with no +rev.
-            const path = modelOrPath as string;
-            const slashIdx = path.indexOf('/');
-            const plusIdx = path.indexOf('+', slashIdx);
-            if (slashIdx > 0 && !forcePrivate) {
-                this.path = path;
-                this.id = path.substring(slashIdx + 1, plusIdx > slashIdx ? plusIdx : undefined);
-                this.revision = plusIdx > slashIdx ? +path.substring(plusIdx + 1) : undefined;
-                this.key = path.substring(slashIdx + 1);
-                this.level = 'protected';
-                this.identityId = path.substring(0, slashIdx);
-            } else {
-                this.path = path;
-                this.id = plusIdx > 0 ? path.substring(0, plusIdx) : path;
-                this.revision = plusIdx > 0 ? +path.substring(plusIdx + 1) : undefined;
-                this.key = path;
-                this.level = 'private';
-            }
-        } else if ((modelOrPath as Collection).authorUserId) {
-            const collection = modelOrPath as Collection;
-            const isPublic = collection.isPublic && !forcePrivate;
-            this.level = isPublic ? 'protected' : 'private';
-            this.id = collection.id;
-            this.revision = collection.revision;
-            this.key = isPublic ? collection.id : collection.id + '+' + collection.revision;
-            this.identityId = collection.isPublic ? collection.authorUserId : undefined;
-            this.path = collection.isPublic ? collection.authorUserId + '/' + this.key : this.key;
-        } else {
-            // Some other AbstractStorableModel - always private
-            const model = modelOrPath as AbstractStorableModel;
-            this.id = model.id;
-            this.revision = model.revision;
-            this.key = this.id + '+' + this.revision;
-            this.level = 'private';
-            this.path = this.key;
-        }
-    }
-
-    /**
-     * Create config options for Amplify StorageClass operations
-     * @param doDownload set to true for get operation to download content
-     */
-    toStorageConfig(doDownload?: boolean): any {
-        return {
-            level: this.level,
-            identityId: this.identityId,
-            download: doDownload === true,
-            contentType: "application/json",
-        };
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -77,6 +77,40 @@ div.pad-bottom {
     color: #ccc;
 }
 
+// Text inside of an <hr class="text" data-content="hello">
+hr.text {
+    line-height: 1em;
+    position: relative;
+    outline: 0;
+    border: 0;
+    color: black;
+    text-align: center;
+    height: 1.5em;
+    opacity: .5;
+    &:before {
+        content: '';
+        // use the linear-gradient for the fading effect
+        // use a solid background color for a solid bar
+        background: linear-gradient(to right, transparent, #818078, transparent);
+        position: absolute;
+        left: 0;
+        top: 50%;
+        width: 100%;
+        height: 1px;
+    }
+    &:after {
+        content: attr(data-content);
+        position: relative;
+        display: inline-block;
+
+        padding: 0 .5em;
+        line-height: 1.5em;
+        // this is really the only tricky part, you need to specify the background color of the container element...
+        color: #818078;
+        background-color: #fcfcfa;
+    }
+}
+
 /*
  * Tables
  */


### PR DESCRIPTION
AWS/Amplify:
- Changed Amplify API (AppSync) authentication type from Cognito User Pools to IAM, so that guest users may perform queries.

Web-app changes:
- Modified client app to handle a guest user (app specific changes)
- Broke StorageLocation into its own file to fix circular dependency (based on imports)
- Only allow creating a collection with a cloud account.
- Added app logic for moving data from a local account to a new cloud account.
